### PR TITLE
selectively show refuel option

### DIFF
--- a/src/components/Refuel.tsx
+++ b/src/components/Refuel.tsx
@@ -30,6 +30,8 @@ export const Refuel = () => {
     }
   }, [destChainId]);
 
+  if (destChainId === 1 || destChainId === sourceChainId) return null;
+
   return (
     <div
       className="skt-w flex bg-widget-secondary py-3 pl-4 pr-3 justify-between mt-6 items-center relative"
@@ -47,17 +49,7 @@ export const Refuel = () => {
           </Popover>
         </div>
         <p className="skt-w text-xs text-widget-secondary mt-0.5">
-          {destChainId === 1 ? (
-            <span className="skt-w text-red-500">
-              Refuel isn't supported on Ethereum
-            </span>
-          ) : destChainId === sourceChainId ? (
-            <span className="skt-w text-red-500">
-              Refuel isn't supported for same chain swaps
-            </span>
-          ) : (
-            `Get Gas for transactions on ${mappedChainData?.[destChainId]?.name}`
-          )}
+          Get Gas for transactions on ${mappedChainData?.[destChainId]?.name}
         </p>
       </div>
       <CheckBox

--- a/src/components/Refuel.tsx
+++ b/src/components/Refuel.tsx
@@ -7,7 +7,7 @@ import useMappedChainData from "../hooks/useMappedChainData";
 import { HelpCircle } from "react-feather";
 import { Popover } from "./common/Popover";
 
-export const Refuel = () => {
+export const Refuel = ({ selectivelyShowRefuel }) => {
   const [isChecked, setIsChecked] = useState(false);
   const destChainId = useSelector((state: any) => state.networks.destChainId);
   const sourceChainId = useSelector(
@@ -30,7 +30,11 @@ export const Refuel = () => {
     }
   }, [destChainId]);
 
-  if (destChainId === 1 || destChainId === sourceChainId) return null;
+  if (
+    selectivelyShowRefuel &&
+    (destChainId === 1 || destChainId === sourceChainId)
+  )
+    return null;
 
   return (
     <div
@@ -49,7 +53,17 @@ export const Refuel = () => {
           </Popover>
         </div>
         <p className="skt-w text-xs text-widget-secondary mt-0.5">
-          Get Gas for transactions on ${mappedChainData?.[destChainId]?.name}
+          {destChainId === 1 ? (
+            <span className="skt-w text-red-500">
+              Refuel isn't supported on Ethereum
+            </span>
+          ) : destChainId === sourceChainId ? (
+            <span className="skt-w text-red-500">
+              Refuel isn't supported for same chain swaps
+            </span>
+          ) : (
+            `Get Gas for transactions on ${mappedChainData?.[destChainId]?.name}`
+          )}{" "}
         </p>
       </div>
       <CheckBox

--- a/src/components/Refuel.tsx
+++ b/src/components/Refuel.tsx
@@ -63,7 +63,7 @@ export const Refuel = ({ selectivelyShowRefuel }) => {
             </span>
           ) : (
             `Get Gas for transactions on ${mappedChainData?.[destChainId]?.name}`
-          )}{" "}
+          )}
         </p>
       </div>
       <CheckBox

--- a/src/components/Widget.tsx
+++ b/src/components/Widget.tsx
@@ -144,7 +144,9 @@ export const Widget = (props: WidgetProps) => {
           onTokenChange={props.onDestinationTokenChange}
           onNetworkChange={props.onDestinationNetworkChange}
         />
-        {props.enableRefuel && <Refuel />}
+        {props.enableRefuel && (
+          <Refuel selectivelyShowRefuel={props.selectivelyShowRefuel} />
+        )}
       </div>
       <SingleTxMessage />
       <RouteDetails />

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -62,6 +62,9 @@ export interface WidgetProps {
   // To enable same chain swaps
   enableSameChainSwaps?: boolean;
 
+  // To show refuel option only when it is valid
+  selectivelyShowRefuel?: boolean;
+
   // To include bridges - only the bridges passed will be included
   includeBridges?: supportedBridges[];
 


### PR DESCRIPTION
Introducing `selectivelyShowRefuel` in `WidgetProps`. 

only show refuel option, when it's supported. 

the useEffect in `Refuel` component will still get triggered even if `null` is rendered, ensuring that this is only a display change. 

storybook demo: 
<img width="453" alt="Screen Shot 2023-03-28 at 10 37 34 AM" src="https://user-images.githubusercontent.com/12927159/228322391-a2e72193-9d19-4966-9341-71a9ede3eaec.png">
<img width="394" alt="Screen Shot 2023-03-28 at 10 38 03 AM" src="https://user-images.githubusercontent.com/12927159/228322510-085d909f-c0eb-4e3b-8ea2-94fb21dd7415.png">

 