### PR TITLE
Feature/tailwind prefix

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,6 +25,9 @@ export default [
       postcss({
         plugins: [],
         minimize: true,
+        inject: {
+          insertAt: 'top',
+        },
       }),
       babel({
         exclude: "node_modules/**",

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -287,7 +287,7 @@ export const Input = ({
                 href="https://www.bungee.exchange/refuel"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="skt-w skt-w-anchor text-widget-accent text-medium"
+                className="skt-w skt-w-anchor skt-w-text-widget-accent skt-w-text-medium"
               >
                 Refuel
               </a>{" "}
@@ -305,10 +305,10 @@ export const Input = ({
   }, []);
 
   return (
-    <div className="skt-w mt-3.5">
-      <div className="skt-w flex items-center justify-between">
-        <div className="skt-w flex items-center">
-          <span className="skt-w text-widget-secondary text-sm mr-1.5">
+    <div className="skt-w skt-w-mt-3.5">
+      <div className="skt-w skt-w-flex skt-w-items-center skt-w-justify-between">
+        <div className="skt-w skt-w-flex skt-w-items-center">
+          <span className="skt-w skt-w-text-widget-secondary skt-w-text-sm skt-w-mr-1.5">
             From
           </span>
           <ChainSelect

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -153,10 +153,14 @@ export const Output = ({
 
   // when the default dest n/w is changed
   useEffect(() => {
-    if(!firstNetworkRender && defaultDestNetwork){
-      updateNetwork(supportedNetworks?.find((x:Network) => x.chainId === defaultDestNetwork))
+    if (!firstNetworkRender && defaultDestNetwork) {
+      updateNetwork(
+        supportedNetworks?.find(
+          (x: Network) => x.chainId === defaultDestNetwork
+        )
+      );
     }
-  }, [supportedNetworks, defaultDestNetwork])
+  }, [supportedNetworks, defaultDestNetwork]);
 
   // For Input & tokens
   const [outputAmount, updateOutputAmount] = useState<string>("");
@@ -252,10 +256,12 @@ export const Output = ({
   );
 
   return (
-    <div className="skt-w mt-6">
-      <div className="skt-w flex items-center justify-between">
-        <div className="skt-w flex items-center">
-          <span className="skt-w text-widget-secondary text-sm mr-1.5">To</span>
+    <div className="skt-w skt-w-mt-6">
+      <div className="skt-w skt-w-flex skt-w-items-center skt-w-justify-between">
+        <div className="skt-w skt-w-flex skt-w-items-center">
+          <span className="skt-w skt-w-text-widget-secondary skt-w-text-sm skt-w-mr-1.5">
+            To
+          </span>
           <ChainSelect
             networks={supportedNetworksSubset}
             activeNetworkId={destChainId}

--- a/src/components/PendingTransactions.tsx
+++ b/src/components/PendingTransactions.tsx
@@ -51,7 +51,7 @@ export const PendingTransactions = () => {
     return (
       <>
         <button
-          className="skt-w skt-w-button skt-w-input uppercase text-sm px-2 py-0.5 bg-widget-accent shadow-inner bg-opacity-90 text-widget-onAccent"
+          className="skt-w skt-w-button skt-w-input skt-w-uppercase skt-w-text-sm skt-w-px-2 skt-w-py-0.5 skt-w-bg-widget-accent skt-w-shadow-inner skt-w-bg-opacity-90 skt-w-text-widget-onAccent"
           onClick={() => setIsModalOpen(true)}
           style={{ borderRadius: `calc(0.75rem * ${borderRadius})` }}
         >
@@ -66,8 +66,8 @@ export const PendingTransactions = () => {
                 closeModal={() => setIsModalOpen(false)}
                 style={style}
               >
-                <div className="skt-w flex flex-col justify-start p-1 flex-1 overflow-y-auto">
-                  <p className="skt-w text-widget-secondary text-xs px-3 py-2 text-left">
+                <div className="skt-w skt-w-flex skt-w-flex-col skt-w-justify-start skt-w-p-1 skt-w-flex-1 skt-w-overflow-y-auto">
+                  <p className="skt-w skt-w-text-widget-secondary skt-w-text-xs skt-w-px-3 skt-w-py-2 skt-w-text-left">
                     Transaction status is updated every 30 seconds
                   </p>
 
@@ -99,7 +99,7 @@ export const PendingTransactions = () => {
                     );
                   })}
 
-                  <p className="skt-w text-widget-secondary text-xs px-3 py-2 text-left">
+                  <p className="skt-w skt-w-text-widget-secondary skt-w-text-xs skt-w-px-3 skt-w-py-2 skt-w-text-left">
                     Showing {activeRoutes?.length}/{totalRoutes} active routes
                   </p>
                 </div>

--- a/src/components/Refuel.tsx
+++ b/src/components/Refuel.tsx
@@ -38,27 +38,27 @@ export const Refuel = ({ selectivelyShowRefuel }) => {
 
   return (
     <div
-      className="skt-w flex bg-widget-secondary py-3 pl-4 pr-3 justify-between mt-6 items-center relative"
+      className="skt-w skt-w-flex skt-w-bg-widget-secondary skt-w-py-3 skt-w-pl-4 skt-w-pr-3 skt-w-justify-between skt-w-mt-6 skt-w-items-center skt-w-relative"
       style={{ borderRadius: `calc(0.5rem * ${borderRadius})` }}
     >
-      <div className="mr-1">
-        <div className="skt-w text-sm text-widget-primary font-medium flex items-center">
+      <div className="skt-w-mr-1">
+        <div className="skt-w skt-w-text-sm skt-w-text-widget-primary skt-w-font-medium skt-w-flex skt-w-items-center">
           Enable Refuel
           <Popover
             content="With Refuel, you can swap native tokens on the source chain for native tokens to transact on the destination chain"
-            classNames="-top-14"
+            classNames="skt-w--top-14"
             cursor="cursor-help"
           >
-            <HelpCircle className="skt-w ml-1.5 w-4 h-4 opacity-70" />
+            <HelpCircle className="skt-w skt-w-ml-1.5 skt-w-w-4 skt-w-h-4 skt-w-opacity-70" />
           </Popover>
         </div>
-        <p className="skt-w text-xs text-widget-secondary mt-0.5">
+        <p className="skt-w skt-w-text-xs skt-w-text-widget-secondary skt-w-mt-0.5">
           {destChainId === 1 ? (
-            <span className="skt-w text-red-500">
+            <span className="skt-w skt-w-text-red-500">
               Refuel isn't supported on Ethereum
             </span>
           ) : destChainId === sourceChainId ? (
-            <span className="skt-w text-red-500">
+            <span className="skt-w skt-w-text-red-500">
               Refuel isn't supported for same chain swaps
             </span>
           ) : (

--- a/src/components/RouteDetails/ReviewModal.tsx
+++ b/src/components/RouteDetails/ReviewModal.tsx
@@ -171,9 +171,9 @@ export const ReviewModal = ({
       }
       style={style}
     >
-      <div className="skt-w flex flex-col justify-between flex-1 relative">
+      <div className="skt-w skt-w-flex skt-w-flex-col skt-w-justify-between skt-w-flex-1 skt-w-relative">
         <div
-          className="skt-w w-full overflow-y-auto"
+          className="skt-w skt-w-w-full skt-w-overflow-y-auto"
           style={{ height: "calc(100% - 7rem)" }}
         >
           <TokenDetailsRow
@@ -189,7 +189,7 @@ export const ReviewModal = ({
             destRefuel={refuelDestToken}
           />
 
-          <div className="skt-w px-3 py-1.5 flex flex-col mt-1">
+          <div className="skt-w skt-w-px-3 skt-w-py-1.5 skt-w-flex skt-w-flex-col skt-w-mt-1">
             {!isSameChainSwap ? (
               <>
                 <RouteDetailRow
@@ -245,10 +245,10 @@ export const ReviewModal = ({
                 <div className="flex items-center">
                   {swapData?.swapSlippage ?? swapStepInFundMovr?.swapSlippage}%{" "}
                   <button
-                    className="skt-w skt-w-input skt-w-button flex"
+                    className="skt-w skt-w-input skt-w-button skt-w-flex"
                     onClick={openSettingsModal}
                   >
-                    <Edit className="ml-2 w-4 h-4 text-widget-accent" />
+                    <Edit className="skt-w-ml-2 skt-w-w-4 skt-w-h-4 skt-w-text-widget-accent" />
                   </button>
                 </div>
               </RouteDetailRow>
@@ -266,25 +266,27 @@ export const ReviewModal = ({
         </div>
 
         <InnerCard
-          classNames={`absolute w-full flex bottom-0 flex-col justify-between transition-all ${
-            showTxDetails ? `h-full max-h-full` : "h-auto max-h-min"
+          classNames={`skt-w-absolute skt-w-w-full skt-w-flex skt-w-bottom-0 skt-w-flex-col skt-w-justify-between skt-w-transition-all ${
+            showTxDetails
+              ? `skt-w-h-full skt-w-max-h-full`
+              : "skt-w-h-auto skt-w-max-h-min"
           }`}
         >
-          <div className="skt-w flex-1 flex flex-col overflow-auto">
+          <div className="skt-w skt-w-flex-1 skt-w-flex skt-w-flex-col skt-w-overflow-auto">
             <button
-              className="skt-w skt-w-button skt-w-input flex items-center text-sm text-widget-secondary mb-3"
+              className="skt-w skt-w-button skt-w-input skt-w-flex skt-w-items-center skt-w-text-sm skt-w-text-widget-secondary skt-w-mb-3"
               onClick={() => setShowTxDetails(!showTxDetails)}
             >
               <ChevronUp
-                className={`skt-w w-4 h-4 text-widget-secondary transition-all mr-1.5 ${
-                  showTxDetails ? "rotate-180" : "rotate-0"
+                className={`skt-w skt-w-w-4 skt-w-h-4 skt-w-text-widget-secondary skt-w-transition-all skt-w-mr-1.5 ${
+                  showTxDetails ? "skt-w-rotate-180" : "skt-w-rotate-0"
                 }`}
               />{" "}
               See route details
             </button>
 
             {showTxDetails && (
-              <div className="skt-w mb-3 flex-1 overflow-y-auto">
+              <div className="skt-w skt-w-mb-3 skt-w-flex-1 skt-w-overflow-y-auto">
                 <TxStepDetails
                   activeRoute={selectedRoute?.route}
                   forReview
@@ -295,22 +297,22 @@ export const ReviewModal = ({
           </div>
 
           <div
-            className={`skt-w h-14 transition-all duration-300 flex justify-between items-center border ${
+            className={`skt-w skt-w-h-14 skt-w-transition-all skt-w-duration-300 skt-w-flex skt-w-justify-between skt-w-items-center skt-w-border ${
               quoteUpdated
-                ? "border-widget-outline p-1 pl-2"
-                : "border-transparent"
+                ? "skt-w-border-widget-outline skt-w-p-1 skt-w-pl-2"
+                : "skt-w-border-transparent"
             }`}
             style={{ borderRadius: `calc(0.875rem * ${borderRadius})` }}
           >
             {quoteUpdated && (
-              <span className="skt-w whitespace-nowrap w-full text-widget-secondary text-sm text-left">
+              <span className="skt-w skt-w-whitespace-nowrap skt-w-w-full skt-w-text-widget-secondary skt-w-text-sm skt-w-text-left">
                 {!bestRoute ? "Quote updating..." : "Quote updated"}
               </span>
             )}
 
             <Button
               onClick={quoteUpdated ? updateSelectedRoute : openTxModal}
-              classNames={`${quoteUpdated ? "h-12" : ""}`}
+              classNames={`${quoteUpdated ? "skt-w-h-12" : ""}`}
               disabled={!bestRoute}
             >
               {quoteUpdated
@@ -334,7 +336,7 @@ const RouteDetailRow = ({
   children?: ReactNode;
 }) => {
   return (
-    <div className="skt-w w-full flex justify-between text-sm text-widget-secondary my-1.5">
+    <div className="skt-w skt-w-w-full skt-w-flex skt-w-justify-between skt-w-text-sm skt-w-text-widget-secondary skt-w-my-1.5">
       <span>{label}</span>
       <span>{value}</span>
       {children}
@@ -356,13 +358,13 @@ const FeeDisplay = (props: FeeDisplayProps) => {
         {!!feeInToken && feeInToken !== "0" ? (
           <span>
             {truncateDecimalValue(feeInToken, 5)}{" "}
-            <span className="font-medium">{tokenSymbol}</span>{" "}
+            <span className="skt-w-font-medium">{tokenSymbol}</span>{" "}
           </span>
         ) : (
           0
         )}
         {feeInUsd !== 0 && (
-          <span className="opacity-80 font-normal">
+          <span className="skt-w-opacity-80 skt-w-font-normal">
             (${feeInUsd?.toFixed(4)})
           </span>
         )}

--- a/src/components/RouteDetails/index.tsx
+++ b/src/components/RouteDetails/index.tsx
@@ -29,7 +29,9 @@ import { SortOptions } from "@socket.tech/socket-v2-sdk";
 export const RouteDetails = () => {
   const dispatch = useDispatch();
 
-  const sourceChainId = useSelector((state: any) => state.networks.sourceChainId)
+  const sourceChainId = useSelector(
+    (state: any) => state.networks.sourceChainId
+  );
   const sourceToken = useSelector((state: any) => state.tokens.sourceToken);
   const destToken = useSelector((state: any) => state.tokens.destToken);
   const sortPref = useSelector((state: any) => state.quotes.sortPref);
@@ -98,7 +100,8 @@ export const RouteDetails = () => {
   useEffect(() => {
     if (data) {
       // Reversing the order in case of sort-by-time because the API returns the list in descendind order of service time
-      const bestRoute = sortPref === SortOptions.Time ? data.reverse()[0] : data[0];
+      const bestRoute =
+        sortPref === SortOptions.Time ? data.reverse()[0] : data[0];
       dispatch(setBestRoute(bestRoute));
 
       // Check if there is sufficient native token for refuel
@@ -206,13 +209,13 @@ export const RouteDetails = () => {
 
   return (
     <InnerCard>
-      <div className="skt-w text-widget-secondary mb-3 text-sm flex items-center">
+      <div className="skt-w skt-w-text-widget-secondary skt-w-mb-3 skt-w-text-sm skt-w-flex skt-w-items-center">
         {sourceAmount && sourceAmount !== "0" && isQuotesLoading ? (
-          <span className="mr-1">
+          <span className="skt-w-mr-1">
             <Spinner size={4} />
           </span>
         ) : !!bestRoute?.refuel && !isNativeTokenEnough ? (
-          <Info className="w-4 h-4 mr-1" />
+          <Info className="skt-w-w-4 skt-w-h-4 skt-w-mr-1" />
         ) : (
           ""
         )}
@@ -229,7 +232,7 @@ export const RouteDetails = () => {
       >
         {getButtonStatus()}
       </Button>
-      <div className="skt-w flex items-center justify-between text-widget-secondary mt-2.5 text-xs">
+      <div className="skt-w skt-w-flex skt-w-items-center skt-w-justify-between skt-w-text-widget-secondary skt-w-mt-2.5 skt-w-text-xs">
         <a
           href="http://socket.tech/"
           target="_blank"

--- a/src/components/Settings/SettingsModal.tsx
+++ b/src/components/Settings/SettingsModal.tsx
@@ -36,9 +36,9 @@ export const SettingsModal = () => {
               title="Settings"
               closeModal={() => toggleSettingsModal(false)}
               style={style}
-              classNames="z-50"
+              classNames="skt-w-z-50"
             >
-              <div className="skt-w px-3 pt-3">
+              <div className="skt-w skt-w-px-3 skt-w-pt-3">
                 {/* Sort options */}
                 <SortPreference />
 

--- a/src/components/Settings/SingleTx.tsx
+++ b/src/components/Settings/SingleTx.tsx
@@ -29,18 +29,18 @@ export const SingleTx = () => {
 
   if (singleTxOnlyFromDev) return null;
   return (
-    <div className="skt-w flex items-center relative mt-6 justify-between">
-      <div className="skt-w flex items-center mb-1.5">
+    <div className="skt-w skt-w-flex skt-w-items-center skt-w-relative skt-w-mt-6 skt-w-justify-between">
+      <div className="skt-w skt-w-flex skt-w-items-center skt-w-mb-1.5">
         <SubTitle>Single Transaction Mode</SubTitle>
         <Popover
           content="Only select routes with one user transaction i.e. direct bridge or source chain swap + bridge."
-          classNames="bottom-8"
+          classNames="skt-w-bottom-8"
           cursor="cursor-help"
         >
-          <Info className="ml-1.5 w-4 h-4 text-widget-secondary" />
+          <Info className="skt-w-ml-1.5 skt-w-w-4 skt-w-h-4 skt-w-text-widget-secondary" />
         </Popover>
       </div>
-      <span className="px-1"></span>
+      <span className="skt-w-px-1"></span>
       <CheckBox
         small
         id="singleTx"

--- a/src/components/Settings/SortPreference.tsx
+++ b/src/components/Settings/SortPreference.tsx
@@ -43,24 +43,24 @@ export const SortPreference = () => {
   }, []);
 
   return (
-    <div className="skt-w flex items-center relative z-30 justify-between">
+    <div className="skt-w skt-w-flex skt-w-items-center skt-w-relative skt-w-z-30 skt-w-justify-between">
       <SubTitle>Preferred Route</SubTitle>
       <div
-        className="skt-w relative border border-widget-secondary-text border-opacity-40 flex w-auto ml-2"
+        className="skt-w skt-w-relative skt-w-border skt-w-border-widget-secondary-text skt-w-border-opacity-40 skt-w-flex skt-w-w-auto skt-w-ml-2"
         style={{ borderRadius: `calc(0.375rem * ${borderRadius})` }}
         ref={dropdownRef}
       >
         <Option onClick={() => openDropdown(!dropdown)} active>
           {label}{" "}
           <ChevronDown
-            className={`skt-w w-4 h-4 text-widget-secondary transition-all ${
+            className={`skt-w skt-w-w-4 skt-w-h-4 skt-w-text-widget-secondary skt-w-transition-all ${
               dropdown ? "rotate-180" : ""
             }`}
           />
         </Option>
         {dropdown && (
           <div
-            className="skt-w absolute top-10 left-0 w-full border border-widget-secondary-text border-opacity-40 overflow-hidden bg-widget-primary"
+            className="skt-w skt-w-absolute skt-w-top-10 skt-w-left-0 skt-w-w-full skt-w-border skt-w-border-widget-secondary-text skt-w-border-opacity-40 skt-w-overflow-hidden skt-w-bg-widget-primary"
             style={{
               borderRadius: `calc(0.375rem * ${borderRadius})`,
             }}
@@ -90,8 +90,8 @@ const Option = ({
 }) => {
   return (
     <button
-      className={`skt-w skt-w-input skt-w-button w-32 px-2 py-2 text-widget-secondary text-sm flex items-center justify-between ${
-        active ? "" : "hover:bg-widget-secondary"
+      className={`skt-w skt-w-input skt-w-button skt-w-w-32 skt-w-px-2 skt-w-py-2 skt-w-text-widget-secondary skt-w-text-sm skt-w-flex skt-w-items-center skt-w-justify-between ${
+        active ? "" : "hover:skt-w-bg-widget-secondary"
       }`}
       onClick={onClick}
     >

--- a/src/components/Settings/SubTitle.tsx
+++ b/src/components/Settings/SubTitle.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from "react";
 
 export const SubTitle = ({ children }: { children: ReactNode }) => {
   return (
-    <p className="skt-w text-sm text-widget-primary font-medium">{children}</p>
+    <p className="skt-w skt-w-text-sm skt-w-text-widget-primary skt-w-font-medium">
+      {children}
+    </p>
   );
 };

--- a/src/components/Settings/SwapSlippage.tsx
+++ b/src/components/Settings/SwapSlippage.tsx
@@ -101,25 +101,25 @@ export const SwapSlippage = () => {
   );
 
   return (
-    <div className="mt-6">
-      <div className="flex justify-between relative">
-        <div className="skt-w flex items-center mb-1.5">
+    <div className="skt-w-mt-6">
+      <div className="skt-w-flex skt-w-justify-between skt-w-relative">
+        <div className="skt-w skt-w-flex skt-w-items-center skt-w-mb-1.5">
           <SubTitle>Swap Slippage</SubTitle>
           <Popover
             content="Your swap transaction will revert if the price changes unfavourably by more than this percentage."
-            classNames="bottom-8"
+            classNames="skt-w-bottom-8"
             cursor="cursor-help"
           >
-            <Info className="ml-1.5 w-4 h-4 text-widget-secondary" />
+            <Info className="skt-w-ml-1.5 skt-w-w-4 skt-w-h-4 skt-w-text-widget-secondary" />
           </Popover>
         </div>
         {buttonInput || customInput ? (
-          <span className="text-xs text-widget-secondary ml-3">
+          <span className="skt-w-text-xs skt-w-text-widget-secondary skt-w-ml-3">
             Slippage: {buttonInput ?? customInput}%
           </span>
         ) : null}
       </div>
-      <div className="flex -mx-1">
+      <div className="skt-w-flex skt-w--mx-1">
         <RadioCheckbox
           id="swap-slippage-1"
           name="swap-slippage"

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -14,9 +14,9 @@ export const Settings = () => {
     <>
       <button
         onClick={() => toggleSettingsModal(true)}
-        className="skt-w skt-w-button skt-w-input flex ml-3"
+        className="skt-w skt-w-button skt-w-input skt-w-flex skt-w-ml-3"
       >
-        <SettingsIcon className="skt-w w-5.5 h-5.5 text-widget-secondary hover:text-widget-primary hover:rotate-45 duration-200 ease-linear" />
+        <SettingsIcon className="skt-w skt-w-w-5.5 skt-w-h-5.5 skt-w-text-widget-secondary hover:skt-w-text-widget-primary hover:skt-w-rotate-45 skt-w-duration-200 skt-w-ease-linear" />
       </button>
     </>
   );

--- a/src/components/TokenInput/RefuelAmount.tsx
+++ b/src/components/TokenInput/RefuelAmount.tsx
@@ -13,7 +13,7 @@ export const RefuelAmount = ({ src = false }: { src?: boolean }) => {
   if (!refuel) return null;
 
   return (
-    <span className="skt-w text-widget-accent text-xs absolute left-0 -bottom-5">
+    <span className="skt-w skt-w-text-widget-accent skt-w-text-xs skt-w-absolute skt-w-left-0 skt-w--bottom-5">
       + {amount} {src ? refuel?.fromAsset?.symbol : refuel?.toAsset?.symbol}
     </span>
   );

--- a/src/components/TokenInput/SearchBar.tsx
+++ b/src/components/TokenInput/SearchBar.tsx
@@ -15,14 +15,14 @@ export const SearchBar = (props: SearchBarProps) => {
 
   return (
     <div
-      className="skt-w flex items-center px-2 w-full bg-widget-primary border border-widget-secondary-text/30 text-widget-primary text-sm overflow-hidden focus-within:border-widget-secondary-text relative"
+      className="skt-w skt-w-flex skt-w-items-center skt-w-px-2 skt-w-w-full skt-w-bg-widget-primary skt-w-border skt-w-border-widget-secondary-text/30 skt-w-text-widget-primary skt-w-text-sm skt-w-overflow-hidden focus-within:skt-w-border-widget-secondary-text skt-w-relative"
       style={{ borderRadius: `calc(0.5rem * ${borderRadius})` }}
     >
-      <Search className="skt-w w-5 h-5 text-widget-secondary mr-2" />
+      <Search className="skt-w skt-w-w-5 skt-w-h-5 skt-w-text-widget-secondary skt-w-mr-2" />
       <input
         onChange={(e) => handleInput(e.target.value)}
         placeholder="Search Name or Address"
-        className="stk-w skt-w-input w-full border-none py-2 pr-7 bg-transparent overflow-x-hidden overflow-ellipsis"
+        className="stk-w skt-w-input skt-w-w-full skt-w-border-none skt-w-py-2 skt-w-pr-7 skt-w-bg-transparent skt-w-overflow-x-hidden skt-w-overflow-ellipsis"
         role="search"
         value={searchInput}
         spellCheck={false}
@@ -30,7 +30,7 @@ export const SearchBar = (props: SearchBarProps) => {
 
       {!!searchInput && (
         <XCircle
-          className="skt-w bg-widget-primary w-5 h-5 text-widget-secondary hover:text-secondary absolute right-3 top-.25 cursor-pointer"
+          className="skt-w skt-w-bg-widget-primary skt-w-w-5 skt-w-h-5 skt-w-text-widget-secondary hover:skt-w-text-secondary skt-w-absolute skt-w-right-3 skt-w-top-.25 skt-w-cursor-pointer"
           onClick={() => {
             setSearchInput("");
             handleInput("");

--- a/src/components/TokenInput/TokenSelect.tsx
+++ b/src/components/TokenInput/TokenSelect.tsx
@@ -110,16 +110,16 @@ export const TokenSelect = (props: Props) => {
       {activeToken && (
         <button
           onClick={() => setOpenTokenList(!openTokenList)}
-          className={`skt-w skt-w-input skt-w-button flex items-center flex-1 bg-widget-interactive flex-shrink-0 flex-nowrap w-auto overflow-hidden p-1 text-widget-on-interactive`}
+          className={`skt-w skt-w-input skt-w-button skt-w-flex skt-w-items-center skt-w-flex-1 skt-w-bg-widget-interactive skt-w-flex-shrink-0 skt-w-flex-nowrap skt-w-w-auto skt-w-overflow-hidden skt-w-p-1 skt-w-text-widget-on-interactive`}
           style={{ borderRadius: `calc(1rem * ${borderRadius})` }}
         >
           <img
             src={activeToken?.logoURI}
-            className="skt-w h-6 w-6 rounded-full mr-1.5 border"
+            className="skt-w skt-w-h-6 skt-w-w-6 skt-w-rounded-full skt-w-mr-1.5 skt-w-border"
           />
-          <div className="skt-w flex items-center">
-            <span className="mr-0.5">{activeToken?.symbol}</span>
-            <ChevronDown className="skt-w w-4 h-4" />
+          <div className="skt-w skt-w-flex skt-w-items-center">
+            <span className="skt-w-mr-0.5">{activeToken?.symbol}</span>
+            <ChevronDown className="skt-w skt-w-w-4 skt-w-h-4" />
           </div>
         </button>
       )}
@@ -135,36 +135,38 @@ export const TokenSelect = (props: Props) => {
               }}
               style={style}
             >
-              <div className="skt-w px-1.5 pt-2 mb-2">
+              <div className="skt-w skt-w-px-1.5 skt-w-pt-2 skt-w-mb-2">
                 <SearchBar
                   searchInput={searchInput}
                   setSearchInput={setSearchInput}
                   handleInput={(e) => handleSearchInput(e)}
                 />
               </div>
-              <div className="skt-w h-full overflow-y-auto p-1.5">
+              <div className="skt-w skt-w-h-full skt-w-overflow-y-auto skt-w-p-1.5">
                 {displayTokens?.map((token: Currency) => {
                   return (
                     <button
-                      className="skt-w skt-w-input skt-w-button flex hover:bg-widget-secondary items-center p-2 w-full justify-between disabled:opacity-60 disabled:pointer-events-none"
+                      className="skt-w skt-w-input skt-w-button skt-w-flex hover:skt-w-bg-widget-secondary skt-w-items-center skt-w-p-2 skt-w-w-full skt-w-justify-between disabled:skt-w-opacity-60 disabled:skt-w-pointer-events-none"
                       onClick={() => selectToken(token)}
                       key={token?.address}
                       style={{ borderRadius: `calc(0.5rem * ${borderRadius})` }}
                       disabled={tokenToDisable?.address === token?.address}
                     >
-                      <div className="skt-w flex items-center">
+                      <div className="skt-w skt-w-flex skt-w-items-center">
                         <img
                           src={token?.logoURI}
-                          className="skt-w w-6 h-6 rounded-full"
+                          className="skt-w skt-w-w-6 skt-w-h-6 skt-w-rounded-full"
                         />
-                        <div className="skt-w flex flex-col items-start ml-2 text-widget-secondary">
-                          <span className="skt-w text-sm">{token?.symbol}</span>
-                          <span className="skt-w text-xs -mt-0.5">
+                        <div className="skt-w skt-w-flex skt-w-flex-col skt-w-items-start skt-w-ml-2 skt-w-text-widget-secondary">
+                          <span className="skt-w skt-w-text-sm">
+                            {token?.symbol}
+                          </span>
+                          <span className="skt-w skt-w-text-xs skt-w--mt-0.5">
                             {token?.name}
                           </span>
                         </div>
                       </div>
-                      <span className="skt-w text-widget-secondary text-xs text-right font-medium">
+                      <span className="skt-w skt-w-text-widget-secondary skt-w-text-xs skt-w-text-right skt-w-font-medium">
                         {showBalance(token)}
                       </span>
                     </button>

--- a/src/components/TokenInput/index.tsx
+++ b/src/components/TokenInput/index.tsx
@@ -23,14 +23,14 @@ export const TokenInput = (props: TokenInputProps) => {
     activeToken,
     tokens,
     noTokens = false,
-    tokenToDisable
+    tokenToDisable,
   } = props;
   return (
-    <div className="skt-w flex items-center justify-between mt-2.5 overflow-hidden pb-[1.125rem]">
-      <div className="skt-w flex flex-1">
-        <div className="stk-w flex flex-col relative">
+    <div className="skt-w skt-w-flex skt-w-items-center skt-w-justify-between skt-w-mt-2.5 skt-w-overflow-hidden skt-w-pb-[1.125rem]">
+      <div className="skt-w skt-w-flex skt-w-flex-1">
+        <div className="stk-w skt-w-flex skt-w-flex-col skt-w-relative">
           <input
-            className={`skt-w skt-w-input text-widget-primary text-3xl focus:outline-none w-full h-full overflow-ellipsis bg-transparent`}
+            className={`skt-w skt-w-input skt-w-text-widget-primary skt-w-text-3xl focus:skt-w-outline-none skt-w-w-full skt-w-h-full skt-w-overflow-ellipsis skt-w-bg-transparent`}
             value={amount}
             onChange={(e) => onChangeInput(e.target.value)}
             placeholder="0.0"

--- a/src/components/TxModal/BridgingLoader.tsx
+++ b/src/components/TxModal/BridgingLoader.tsx
@@ -105,7 +105,7 @@ export const BridgingLoader = ({
   };
 
   return (
-    <div className="skt-w absolute bg-widget-primary h-full w-full top-0 left-0 flex flex-col">
+    <div className="skt-w skt-w-absolute skt-w-bg-widget-primary skt-w-h-full skt-w-w-full skt-w-top-0 skt-w-left-0 skt-w-flex skt-w-flex-col">
       <TokenDetailsRow
         srcDetails={{
           token: currentRoute?.sourceTokenDetails?.token,
@@ -118,15 +118,15 @@ export const BridgingLoader = ({
         srcRefuel={refuelSourceToken}
         destRefuel={refuelDestToken}
       />
-      <div className="skt-w border-b border-widget-secondary" />
+      <div className="skt-w skt-w-border-b skt-w-border-widget-secondary" />
 
-      <div className="skt-w flex flex-col items-center my-auto pb-3">
+      <div className="skt-w skt-w-flex skt-w-flex-col skt-w-items-center skt-w-my-auto skt-w-pb-3">
         <Spinner size={10} />
         <div className="mt-4">
-          <p className="skt-w text-sm text-widget-primary mb-2 font-medium text-center">
+          <p className="skt-w skt-w-text-sm skt-w-text-widget-primary skt-w-mb-2 skt-w-font-medium skt-w-text-center">
             Bridging in progress
           </p>
-          <p className="skt-w text-xs font-normal text-widget-secondary mb-3 text-center px-3">
+          <p className="skt-w skt-w-text-xs skt-w-font-normal skt-w-text-widget-secondary skt-w-mb-3 skt-w-text-center skt-w-px-3">
             {showSupportLink ? (
               <span>
                 Get in touch for support on{" "}
@@ -134,7 +134,7 @@ export const BridgingLoader = ({
                   href="https://discord.gg/23Gk2Fa9JZ"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="skt-w skt-w-anchor underline"
+                  className="skt-w skt-w-anchor skt-w-underline"
                 >
                   Discord
                 </a>
@@ -150,14 +150,14 @@ export const BridgingLoader = ({
           </p>
         </div>
 
-        <div className="skt-w flex flex-col items-center mt-4">
+        <div className="skt-w skt-w-flex skt-w-flex-col skt-w-items-center skt-w-mt-4">
           <TxRow
             title={`Bridging via ${bridgeDetails?.protocol?.displayName}`}
             srcUrl={srcTxHash}
             destUrl={destTxHash}
           />
           {!!refuelEnabled && (
-            <div className="mt-3.5">
+            <div className="skt-w-mt-3.5">
               <TxRow title="Refuel" destUrl={destRefuelTxHash} />
             </div>
           )}
@@ -165,7 +165,7 @@ export const BridgingLoader = ({
       </div>
 
       {explorerParams?.srcTxHash && (
-        <div className="mb-10">
+        <div className="skt-w-mb-10">
           <SocketScanLink txHash={explorerParams?.srcTxHash} />
         </div>
       )}
@@ -178,7 +178,7 @@ const TxUrlChip = ({ url, label }: { url?: string; label: string }) => {
   const { borderRadius } = customSettings.customization;
   return (
     <span
-      className="skt-w text-xs bg-widget-primary text-widget-secondary flex items-center flex-nowrap px-2 py-1.5"
+      className="skt-w skt-w-text-xs skt-w-bg-widget-primary skt-w-text-widget-secondary skt-w-flex skt-w-items-center skt-w-flex-nowrap skt-w-px-2 skt-w-py-1.5"
       style={{ borderRadius: `calc(1rem * ${borderRadius})` }}
     >
       {url && !url.match("undefined") ? (
@@ -186,14 +186,14 @@ const TxUrlChip = ({ url, label }: { url?: string; label: string }) => {
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="skt-w skt-w-anchor flex items-center hover:underline"
+          className="skt-w skt-w-anchor skt-w-flex skt-w-items-center hover:skt-w-underline"
         >
           {label}{" "}
-          <ExternalLink className="skt-w text-widget-secondary w-3 h-auto ml-1.5" />
+          <ExternalLink className="skt-w skt-w-text-widget-secondary skt-w-w-3 skt-w-h-auto skt-w-ml-1.5" />
         </a>
       ) : (
-        <span className="skt-w flex items-center h-auto">
-          <span className="mr-1.5">{label}</span> <Spinner size={3} />
+        <span className="skt-w skt-w-flex skt-w-items-center skt-w-h-auto">
+          <span className="skt-w-mr-1.5">{label}</span> <Spinner size={3} />
         </span>
       )}
     </span>
@@ -210,11 +210,13 @@ const TxRow = ({
   destUrl?: string;
 }) => {
   return (
-    <div className="skw-w flex items-center pl-2.5 p-0.5 rounded-full bg-widget-secondary border border-widget-secondary">
-      <span className="skt-w text-widget-primary text-xs pr-2">{title}</span>
-      <div className="skt-w flex items-center">
+    <div className="skw-w skt-w-flex skt-w-items-center skt-w-pl-2.5 skt-w-p-0.5 skt-w-rounded-full skt-w-bg-widget-secondary skt-w-border skt-w-border-widget-secondary">
+      <span className="skt-w skt-w-text-widget-primary skt-w-text-xs skt-w-pr-2">
+        {title}
+      </span>
+      <div className="skt-w skt-w-flex skt-w-items-center">
         {!!srcUrl && (
-          <span className="mr-0.5">
+          <span className="skt-w-mr-0.5">
             <TxUrlChip label="Src tx" url={srcUrl} />
           </span>
         )}

--- a/src/components/TxModal/SuccessToast.tsx
+++ b/src/components/TxModal/SuccessToast.tsx
@@ -6,15 +6,21 @@ import { animated, useSpring } from "@react-spring/web";
 export const SuccessToast = () => {
   const customSettings = useContext(CustomizeContext);
   const { borderRadius } = customSettings.customization;
-  const animationProps = useSpring({ from: { bottom: -100, opacity: 0 }, to: { bottom: 12, opacity: 1 }});
+  const animationProps = useSpring({
+    from: { bottom: -100, opacity: 0 },
+    to: { bottom: 12, opacity: 1 },
+  });
 
   return (
     <animated.div
-      className="skt-w bg-widget-accent text-widget-onAccent p-4 flex items-center absolute left-3 right-3"
-      style={{ borderRadius: `calc(0.625rem * ${borderRadius})`, ...animationProps }}
+      className="skt-w skt-w-bg-widget-accent skt-w-text-widget-onAccent skt-w-p-4 skt-w-flex skt-w-items-center skt-w-absolute skt-w-left-3 skt-w-right-3"
+      style={{
+        borderRadius: `calc(0.625rem * ${borderRadius})`,
+        ...animationProps,
+      }}
     >
-      <CheckCircle className="skt-w mr-3 text-widget-onAccent" /> Transaction is
-      complete
+      <CheckCircle className="skt-w skt-w-mr-3 skt-w-text-widget-onAccent" />{" "}
+      Transaction is complete
     </animated.div>
   );
 };

--- a/src/components/TxModal/TxStepDetails.tsx
+++ b/src/components/TxModal/TxStepDetails.tsx
@@ -32,7 +32,7 @@ export const TxStepDetails = ({
   const mappedChainData = useMappedChainData();
 
   return (
-    <div className="skt-w flex flex-col text-sm -my-2">
+    <div className="skt-w skt-w-flex skt-w-flex-col skt-w-text-sm skt-w--my-2">
       {activeRoute?.userTxs?.map((tx, txIndex) => {
         const txComplete =
           tx?.userTxStatus === "completed" ||
@@ -107,7 +107,7 @@ export const TxStepDetails = ({
 
           return (
             <div
-              className="skt-w flex flex-col text-sm"
+              className="skt-w skt-w-flex skt-w-flex-col skt-w-text-sm"
               key={`${activeRoute?.activeRouteId}-fund-movr-swap`}
             >
               {isSwap ? (
@@ -121,14 +121,14 @@ export const TxStepDetails = ({
                   bridgeTx
                   txHash={_txHash}
                 >
-                  <div className="skt-w flex flex-col">
-                    <span className="my-1">
+                  <div className="skt-w skt-w-flex skt-w-flex-col">
+                    <span className="skt-w-my-1">
                       {Number(swapSrc?.amount).toFixed(3)} {swapSrc?.symbol} for{" "}
                       {Number(swapDest?.amount).toFixed(3)} {swapDest?.symbol}{" "}
                       via {swapDest?.protocolName} on{" "}
                       {mappedChainData?.[swapSrc.chainId]?.name}
                     </span>
-                    <span className="my-1">
+                    <span className="skt-w-my-1">
                       {Number(bridgeSrc?.amount).toFixed(3)} {bridgeSrc?.symbol}{" "}
                       on {mappedChainData?.[bridgeSrc?.chainId]?.name} to{" "}
                       {Number(bridgeDest?.amount).toFixed(3)}{" "}
@@ -140,16 +140,16 @@ export const TxStepDetails = ({
                           href={destinationTxUrl}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="skt-w skt-w-anchor underline inline-flex items-center text-widget-primary"
+                          className="skt-w skt-w-anchor skt-w-underline skt-w-inline-flex skt-w-items-center skt-w-text-widget-primary"
                         >
                           Dest tx{" "}
-                          <ExternalLink className="skt-w w-3 h-3 ml-1" />
+                          <ExternalLink className="skt-w skt-w-w-3 skt-w-h-3 skt-w-ml-1" />
                         </a>
                       )}
                     </span>
                     {refuel && (
-                      <span className="mt-1">
-                        <span className="skt-w text-widget-accent">
+                      <span className="skt-w-mt-1">
+                        <span className="skt-w skt-w-text-widget-accent">
                           For Refuel :{" "}
                         </span>
                         {Number(refuelSrc?.amount).toFixed(3)}{" "}
@@ -164,10 +164,10 @@ export const TxStepDetails = ({
                             href={refuelDestinationTxUrl}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="skt-w skt-w-anchor underline inline-flex items-center text-widget-primary"
+                            className="skt-w skt-w-anchor skt-w-underline skt-w-inline-flex skt-w-items-center skt-w-text-widget-primary"
                           >
                             Dest tx{" "}
-                            <ExternalLink className="skt-w w-3 h-3 ml-1" />
+                            <ExternalLink className="skt-w skt-w-w-3 skt-w-h-3 skt-w-ml-1" />
                           </a>
                         )}
                       </span>
@@ -185,8 +185,8 @@ export const TxStepDetails = ({
                   bridgeTx
                   txHash={_txHash}
                 >
-                  <div className="skt-w flex flex-col -my-1">
-                    <span className="my-1">
+                  <div className="skt-w skt-w-flex skt-w-flex-col skt-w--my-1">
+                    <span className="skt-w-my-1">
                       {Number(bridgeSrc?.amount).toFixed(3)} {bridgeSrc?.symbol}{" "}
                       on {mappedChainData?.[bridgeSrc?.chainId]?.name} to{" "}
                       {Number(bridgeDest?.amount).toFixed(3)}{" "}
@@ -198,17 +198,17 @@ export const TxStepDetails = ({
                           href={destinationTxUrl}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="skt-w skt-w-anchor underline inline-flex items-center text-widget-primary"
+                          className="skt-w skt-w-anchor skt-w-underline skt-w-inline-flex skt-w-items-center skt-w-text-widget-primary"
                         >
                           Dest tx{" "}
-                          <ExternalLink className="skt-w w-3 h-3 ml-1" />
+                          <ExternalLink className="skt-w skt-w-w-3 skt-w-h-3 skt-w-ml-1" />
                         </a>
                       )}
                     </span>
                     {/* Refuel statement */}
                     {refuel && (
-                      <span className="my-1">
-                        <span className="skt-w text-widget-accent">
+                      <span className="skt-w-my-1">
+                        <span className="skt-w skt-w-text-widget-accent">
                           For Refuel :{" "}
                         </span>
                         {Number(refuelSrc?.amount).toFixed(3)}{" "}
@@ -223,10 +223,10 @@ export const TxStepDetails = ({
                             href={refuelDestinationTxUrl}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="skt-w skt-w-anchor underline inline-flex items-center text-widget-primary"
+                            className="skt-w skt-w-anchor skt-w-underline skt-w-inline-flex skt-w-items-center skt-w-text-widget-primary"
                           >
                             Dest tx{" "}
-                            <ExternalLink className="skt-w w-3 h-3 ml-1" />
+                            <ExternalLink className="skt-w skt-w-w-3 skt-w-h-3 skt-w-ml-1" />
                           </a>
                         )}
                       </span>
@@ -287,7 +287,7 @@ const TxStep = ({
   inProgress = false,
   forReview = false,
   bridgeTx = false,
-  txHash
+  txHash,
 }: {
   label: string;
   children: ReactNode;
@@ -304,53 +304,55 @@ const TxStep = ({
   const { borderRadius } = customSettings.customization;
   return (
     <div
-      className={`skt-w flex border my-2 ${
+      className={`skt-w skt-w-flex skt-w-border skt-w-my-2 ${
         currentTx
-          ? "bg-widget-secondary bg-opacity-20 border-widget-accent"
-          : "border-widget-secondary"
-      } ${forReview ? "" : "p-3"}`}
+          ? "skt-w-bg-widget-secondary skt-w-bg-opacity-20 skt-w-border-widget-accent"
+          : "skt-w-border-widget-secondary"
+      } ${forReview ? "" : "skt-w-p-3"}`}
       style={{ borderRadius: `calc(0.5rem * ${borderRadius}` }}
     >
       <div
-        className={`skt-w h-6 w-6 flex items-center justify-center shrink-0 mt-[3px] mr-3.5 ${
-          complete ? "bg-widget-secondary" : "bg-transparent"
+        className={`skt-w skt-w-h-6 skt-w-w-6 skt-w-flex skt-w-items-center skt-w-justify-center skt-w-shrink-0 skt-w-mt-[3px] skt-w-mr-3.5 ${
+          complete ? "skt-w-bg-widget-secondary" : "skt-w-bg-transparent"
         }`}
         style={{ borderRadius: `calc(0.25rem * ${borderRadius})` }}
       >
         {inProgress && currentTx ? (
           <Spinner size={4} />
         ) : complete ? (
-          <CheckCircle className="skt-w w-[18px] h-[18px] text-widget-accent" />
+          <CheckCircle className="skt-w skt-w-w-[18px] skt-w-h-[18px] skt-w-text-widget-accent" />
         ) : (
           <ArrowRight
-            className={`skt-w w-[18px] h-[18px] ${
+            className={`skt-w skt-w-w-[18px] skt-w-h-[18px] ${
               currentTx || forReview
-                ? "text-widget-accent"
-                : "text-widget-secondary opacity-60"
+                ? "skt-w-text-widget-accent"
+                : "skt-w-text-widget-secondary opacity-60"
             }`}
           />
         )}
       </div>
       <div
-        className={`skt-w flex flex-col text-xs text-left text-widget-secondary ${
-          !active && !forReview ? "opacity-60" : ""
+        className={`skt-w skt-w-flex skt-w-flex-col skt-w-text-xs skt-w-text-left skt-w-text-widget-secondary ${
+          !active && !forReview ? "skt-w-opacity-60" : ""
         }`}
       >
         <span
-          className={`skt-w mb-0.5 ${
-            active || forReview ? "font-medium text-widget-primary" : ""
+          className={`skt-w skt-w-mb-0.5 ${
+            active || forReview
+              ? "skt-w-font-medium skt-w-text-widget-primary"
+              : ""
           }`}
         >
           {url ? (
-            <div className="flex items-center">
+            <div className="skt-w-flex skt-w-items-center">
               <a
                 href={url}
-                className="skt-w skt-w-anchor underline flex items-center"
+                className="skt-w skt-w-anchor skt-w-underline skt-w-flex skt-w-items-center"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 {label}{" "}
-                <ExternalLink className="skt-w w-3 h-3 opacity-50 ml-1" />
+                <ExternalLink className="skt-w skt-w-w-3 skt-w-h-3 skt-w-opacity-50 skt-w-ml-1" />
               </a>
               {bridgeTx && <SocketScanUrl txHash={txHash} />}
             </div>
@@ -368,11 +370,12 @@ const SocketScanUrl = ({ txHash }) => {
   return (
     <a
       href={`https://socketscan.io/tx/${txHash}`}
-      className="skt-w skt-w-anchor underline flex items-center ml-2"
+      className="skt-w skt-w-anchor skt-w-underline skt-w-flex skt-w-items-center skt-w-ml-2"
       target="_blank"
       rel="noopener noreferrer"
     >
-      SocketScan <ExternalLink className="skt-w w-3 h-3 opacity-50 ml-1" />
+      SocketScan{" "}
+      <ExternalLink className="skt-w skt-w-w-3 skt-w-h-3 skt-w-opacity-50 skt-w-ml-1" />
     </a>
   );
 };

--- a/src/components/TxModal/index.tsx
+++ b/src/components/TxModal/index.tsx
@@ -422,9 +422,9 @@ export const TxModal = ({
       currentRoute?.destTokenDetails?.token?.chainId;
 
     const _modalTitle = (
-      <span className="flex items-center">
+      <span className="skt-w-flex skt-w-items-center">
         {isSameChainSwap ? "Swap" : "Bridging"} transaction{" "}
-        <span className="text-xs text-widget-primary text-opacity-70 font-normal ml-1">
+        <span className="skt-w-text-xs skt-w-text-widget-primary skt-w-text-opacity-70 skt-w-font-normal skt-w-ml-1">
           {currentRoute?.route?.activeRouteId
             ? ` - #${currentRoute?.route?.activeRouteId}`
             : userTx?.activeRouteId
@@ -492,8 +492,8 @@ export const TxModal = ({
       disableClose={isApproving || txInProgress}
       style={style}
     >
-      <div className="skt-w flex flex-col flex-1 overflow-hidden justify-between relative">
-        <div className="skt-w flex-1 overflow-y-auto">
+      <div className="skt-w skt-w-flex skt-w-flex-col skt-w-flex-1 skt-w-overflow-hidden skt-w-justify-between skt-w-relative">
+        <div className="skt-w skt-w-flex-1 skt-w-overflow-y-auto">
           <TokenDetailsRow
             srcDetails={{
               token: currentRoute?.sourceTokenDetails?.token,
@@ -506,17 +506,17 @@ export const TxModal = ({
             srcRefuel={refuelSourceToken}
             destRefuel={refuelDestToken}
           />
-          <div className="skt-w border-b border-widget-secondary" />
+          <div className="skt-w skt-w-border-b skt-w-border-widget-secondary" />
 
-          <div className="skt-w px-3 py-3">
+          <div className="skt-w skt-w-px-3 skt-w-py-3">
             {!!swapTx && (
-              <p className="skt-w text-widget-primary mb-3 text-xs flex items-center justify-end pr-0.5">
+              <p className="skt-w skt-w-text-widget-primary skt-w-mb-3 skt-w-text-xs skt-w-flex skt-w-items-center skt-w-justify-end skt-w-pr-0.5">
                 Swap slippage: {swapTx?.swapSlippage}%{" "}
                 <button
                   onClick={() => dispatch(setIsSettingsModalOpen(true))}
-                  className="skt-w skt-w-button skt-w-input flex"
+                  className="skt-w skt-w-button skt-w-input skt-w-flex"
                 >
-                  <Edit className="ml-2 w-3 h-3 text-widget-accent" />
+                  <Edit className="skt-w-ml-2 skt-w-w-3 skt-w-h-3 skt-w-text-widget-accent" />
                 </button>
               </p>
             )}
@@ -534,7 +534,7 @@ export const TxModal = ({
           </div>
         </div>
 
-        <div className="skt-w p-3 shrink-0">
+        <div className="skt-w skt-w-p-3 skt-w-shrink-0">
           {!txCompleted && (
             <>
               {retryEnabled ? (

--- a/src/components/Widget.tsx
+++ b/src/components/Widget.tsx
@@ -116,14 +116,14 @@ export const Widget = (props: WidgetProps) => {
         borderRadius: `calc(1rem * ${borderRadius})`,
         minWidth: "360px",
       }}
-      className="relative p-1 overflow-hidden skt-w skt-w-container bg-widget-primary"
+      className="skt-w-relative skt-w-p-1 skt-w-overflow-hidden skt-w skt-w-root-container skt-w-bg-widget-primary"
     >
-      <div className="skt-w p-3 pt-2.5 pb-3.5">
+      <div className="skt-w skt-w-p-3 skt-w-pt-2.5 skt-w-pb-3.5">
         <Header title={title}>
-          <div className="flex items-center skt-w">
+          <div className="skt-w-flex skt-w-items-center skt-w">
             {!props?.provider ? (
-              <span className="flex items-center text-sm skt-w text-widget-secondary">
-                <CreditCard className="w-5 h-5 mr-2 skt-w text-widget-primary" />{" "}
+              <span className="skt-w-flex skt-w-items-center skt-w-text-sm skt-w skt-w-text-widget-secondary">
+                <CreditCard className="skt-w-w-5 skt-w-h-5 skt-w-mr-2 skt-w skt-w-text-widget-primary" />{" "}
                 Please connect your wallet
               </span>
             ) : (
@@ -152,7 +152,14 @@ export const Widget = (props: WidgetProps) => {
       <RouteDetails />
       {transitions(
         (style, item) =>
-          item && <TxModal style={style} onBridge={props?.onBridgeSuccess} onError={props?.onError} onSubmit={props?.onSubmit}/>
+          item && (
+            <TxModal
+              style={style}
+              onBridge={props?.onBridgeSuccess}
+              onError={props?.onError}
+              onSubmit={props?.onSubmit}
+            />
+          )
       )}
       <SettingsModal />
       <ErrorModal />
@@ -176,16 +183,16 @@ const SingleTxMessage = () => {
   }
 
   if (!singleTxOnly || sourceChainId === destChainId)
-    return <p className="skt-w h-5"></p>; // to prevent the layout shift
+    return <p className="skt-w skt-w-h-5"></p>; // to prevent the layout shift
   return (
-    <p className="skt-w text-sm text-widget-secondary pr-3 pl-3.5 flex items-center h-5">
+    <p className="skt-w skt-w-text-sm skt-w-text-widget-secondary skt-w-pr-3 skt-w-pl-3.5 skt-w-flex skt-w-items-center skt-w-h-5">
       Showing single transaction routes only{" "}
       {!singleTxOnlyFromDev && (
         <button
           onClick={openSettingsModal}
-          className="skt-w skt-w-button skt-w-input ml-1.5 flex"
+          className="skt-w skt-w-button skt-w-input skt-w-ml-1.5 skt-w-flex"
         >
-          <Edit className="skt-w w-3.5 h-3.5 text-widget-accent" />
+          <Edit className="skt-w skt-w-w-3.5 skt-w-h-3.5 skt-w-text-widget-accent" />
         </button>
       )}
     </p>

--- a/src/components/common/Balance.tsx
+++ b/src/components/common/Balance.tsx
@@ -19,12 +19,12 @@ export const Balance = ({
   return (
     <button
       disabled={!onClick}
-      className={`skt-w skt-w-input skt-w-button text-widget-primary text-opacity-70 text-xs text-right flex items-center transition-all ${
-        onClick ? "hover:underline" : ""
+      className={`skt-w skt-w-input skt-w-button skt-w-text-widget-primary skt-w-text-opacity-70 skt-w-text-xs skt-w-text-right skt-w-flex skt-w-items-center skt-w-transition-all ${
+        onClick ? "hover:skt-w-underline" : ""
       }`}
       onClick={onClick}
     >
-      <span className="mr-1">Bal: {token && _formattedBalance}</span>
+      <span className="skt-w-mr-1">Bal: {token && _formattedBalance}</span>
       {isLoading && <Spinner size={3} />}
     </button>
   );

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -28,19 +28,18 @@ export const Button = (props: ButtonProps) => {
     <button
       onClick={onClick}
       disabled={disabled}
-      className={`skt-w skt-w-input skt-w-button h-14 px-3 flex items-center justify-center transition-all duration-100 ease-linear w-full bg-widget-accent text-widget-onAccent hover:bg-opacity-90 border-widget-primary 
-      disabled:bg-widget-secondary 
-      disabled:text-widget-secondary 
-      disabled:opacity-50 
-      disabled:font-normal 
-      disabled:border-opacity-50 
-      border 
-      ${
-        classNames || ""
-      }`}
+      className={`skt-w skt-w-input skt-w-button skt-w-h-14 skt-w-px-3 skt-w-flex skt-w-items-center skt-w-justify-center skt-w-transition-all skt-w-duration-100 skt-w-ease-linear skt-w-w-full skt-w-bg-widget-accent skt-w-text-widget-onAccent hover:skt-w-bg-opacity-90 skt-w-border-widget-primary 
+      disabled:skt-w-bg-widget-secondary 
+      disabled:skt-w-text-widget-secondary 
+      disabled:skt-w-opacity-50 
+      disabled:skt-w-font-normal 
+      disabled:skt-w-border-opacity-50 
+      skt-w-border 
+      ${classNames || ""}`}
       style={{ borderRadius: `calc(0.625rem * ${borderRadius})` }}
     >
-      {isLoading && <Spinner size={4} />} <span className="ml-2">{children}</span>
+      {isLoading && <Spinner size={4} />}{" "}
+      <span className="skt-w-ml-2">{children}</span>
     </button>
   );
 };

--- a/src/components/common/ChainSelect.tsx
+++ b/src/components/common/ChainSelect.tsx
@@ -28,21 +28,25 @@ function Option({
 }) {
   return (
     <div
-      className={`skt-w flex w-28 items-center cursor-pointer flex-shrink-0 ${
-        selected ? "" : "p-1.5 hover:bg-widget-secondary hover:bg-opacity-80" 
+      className={`skt-w skt-w-flex skt-w-w-28 skt-w-items-center skt-w-cursor-pointer skt-w-flex-shrink-0 ${
+        selected
+          ? ""
+          : "skt-w-p-1.5 hover:skt-w-bg-widget-secondary hover:skt-w-bg-opacity-80"
       }`}
       onClick={onClick}
     >
-      <div className="skt-w flex items-center">
+      <div className="skt-w skt-w-flex skt-w-items-center">
         <img
           src={network?.icon}
-          className="skt-w h-6 w-6"
+          className="skt-w skt-w-h-6 skt-w-w-6"
           style={{ borderRadius: `calc(0.3rem * ${borderRadius})` }}
         />
-        <span className="skt-w text-sm text-widget-primary mx-1">{network?.name}</span>
+        <span className="skt-w skt-w-text-sm skt-w-text-widget-primary skt-w-mx-1">
+          {network?.name}
+        </span>
       </div>
       {selected && !onlyOneNetwork && (
-        <ChevronDown className="skt-w text-widget-secondary w-4 h-4" />
+        <ChevronDown className="skt-w skt-w-text-widget-secondary skt-w-w-4 skt-w-h-4" />
       )}
       {children}
     </div>
@@ -76,8 +80,8 @@ export function ChainSelect({
           ? null
           : () => setOpenDropdown(!openDropdown)
       }
-      className={`skt-w relative p-1.5 ${
-        openDropdown ? "bg-widget-interactive h-auto" : ""
+      className={`skt-w skt-w-relative skt-w-p-1.5 ${
+        openDropdown ? "skt-w-bg-widget-interactive skt-w-h-auto" : ""
       }`}
       style={{ borderRadius: `calc(0.5rem * ${borderRadius})` }}
       ref={chainDropdownRef}
@@ -91,7 +95,7 @@ export function ChainSelect({
         />
       ) : (
         <span
-          className="skt-w text-sm text-widget-primary bg-widget-secondary py-1.5 px-2"
+          className="skt-w skt-w-text-sm skt-w-text-widget-primary skt-w-bg-widget-secondary skt-w-py-1.5 skt-w-px-2"
           style={{ borderRadius: `calc(0.3rem * ${borderRadius})` }}
         >
           Loading chains
@@ -100,7 +104,7 @@ export function ChainSelect({
 
       {openDropdown && (
         <div
-          className="skt-w pt-1 z-10 left-0 absolute bg-widget-interactive flex flex-col w-full max-h-[150px] overflow-y-auto overflow-hidden"
+          className="skt-w skt-w-pt-1 skt-w-z-10 skt-w-left-0 skt-w-absolute skt-w-bg-widget-interactive skt-w-flex skt-w-flex-col skt-w-w-full skt-w-max-h-[150px] skt-w-overflow-y-auto skt-w-overflow-hidden"
           style={{
             borderBottomRightRadius: `calc(0.75rem * ${borderRadius})`,
             borderBottomLeftRadius: `calc(0.75rem * ${borderRadius})`,

--- a/src/components/common/CheckBox.tsx
+++ b/src/components/common/CheckBox.tsx
@@ -14,21 +14,21 @@ export const CheckBox = ({
   return (
     <label
       htmlFor={id}
-      className={`skt-w w-11 h-7 rounded-full relative ${
-        disabled ? "cursor-not-allowed" : "cursor-pointer"
-      } ${isChecked ? "bg-widget-accent" : "bg-gray-400"} ${
-        small ? "scale-75" : ""
+      className={`skt-w skt-w-w-11 skt-w-h-7 skt-w-rounded-full skt-w-relative ${
+        disabled ? "skt-w-cursor-not-allowed" : "skt-w-cursor-pointer"
+      } ${isChecked ? "skt-w-bg-widget-accent" : "skt-w-bg-gray-400"} ${
+        small ? "skt-w-scale-75" : ""
       }`}
     >
       <div
-        className={`skt-w bg-widget-onAccent bg-opacity-80 h-5 w-5 top-1 absolute rounded-full transition ease-linear duration-200 ${
-          isChecked ? "translate-x-5" : "translate-x-1"
+        className={`skt-w skt-w-bg-widget-onAccent skt-w-bg-opacity-80 skt-w-h-5 skt-w-w-5 skt-w-top-1 skt-w-absolute skt-w-rounded-full skt-w-transition skt-w-ease-linear skt-w-duration-200 ${
+          isChecked ? "skt-w-translate-x-5" : "skt-w-translate-x-1"
         }`}
       ></div>
       <input
         type="checkbox"
-        className={`skt-w skt-w-input w-px h-px opacity-0 ${
-          disabled ? "pointer-events-none" : ""
+        className={`skt-w skt-w-input skt-w-w-px skt-w-h-px skt-w-opacity-0 ${
+          disabled ? "skt-w-pointer-events-none" : ""
         }`}
         id={id}
         onChange={() => setIsChecked(!isChecked)}

--- a/src/components/common/CustomInput.tsx
+++ b/src/components/common/CustomInput.tsx
@@ -9,11 +9,11 @@ export const CustomInputBox = (props: {
   const customSettings = useContext(CustomizeContext);
   const { borderRadius } = customSettings.customization;
   return (
-    <div className="skt-w mx-1 relative">
+    <div className="skt-w skt-w-mx-1 skt-w-relative">
       <input
         type="number"
-        className={`skt-w bg-transparent text-widget-secondary skt-w-input border-[1.5px] border-opacity-40 pb-0.5 h-full w-full px-3 focus:border-widget-accent text-ellipsis ${
-          value ? "border-widget-accent" : ""
+        className={`skt-w skt-w-bg-transparent skt-w-text-widget-secondary skt-w-input skt-w-border-[1.5px] skt-w-border-opacity-40 skt-w-pb-0.5 skt-w-h-full skt-w-w-full skt-w-px-3 focus:skt-w-border-widget-accent skt-w-text-ellipsis ${
+          value ? "skt-w-border-widget-accent" : ""
         }`}
         style={{ borderRadius: `calc(0.375rem * ${borderRadius})` }}
         placeholder="Custom"
@@ -22,7 +22,7 @@ export const CustomInputBox = (props: {
         step=".001"
         min="0"
       />
-      <span className="absolute right-3 top-2 my-auto font-medium bg-widget-primary pl-2 text-widget-primary">
+      <span className="skt-w-absolute skt-w-right-3 skt-w-top-2 skt-w-my-auto skt-w-font-medium skt-w-bg-widget-primary skt-w-pl-2 skt-w-text-widget-primary">
         %
       </span>
     </div>

--- a/src/components/common/DisclaimerBox.tsx
+++ b/src/components/common/DisclaimerBox.tsx
@@ -14,7 +14,7 @@ export const DisclaimerBox = ({
 
   return (
     <div
-      className="skt-w py-3 px-3.5 text-sm text-opacity-90 mt-4 flex items-start"
+      className="skt-w skt-w-py-3 skt-w-px-3.5 skt-w-text-sm skt-w-text-opacity-90 skt-w-mt-4 skt-w-flex skt-w-items-start"
       style={{
         background: "#FAF3E6",
         borderRadius: `calc(0.75rem * ${borderRadius})`,
@@ -22,11 +22,13 @@ export const DisclaimerBox = ({
       role="alert"
     >
       {showIcon && (
-        <div className="flex items-center mb-2">
-          <AlertTriangle className="skt-w mr-3 mt-0.5 text-orange-500" />{" "}
+        <div className="skt-w-flex skt-w-items-center skt-w-mb-2">
+          <AlertTriangle className="skt-w skt-w-mr-3 skt-w-mt-0.5 skt-w-text-orange-500" />{" "}
         </div>
       )}
-      <p className="skt-w text-gray-800 text-left leading-5">{children}</p>
+      <p className="skt-w skt-w-text-gray-800 skt-w-text-left skt-w-leading-5">
+        {children}
+      </p>
     </div>
   );
 };

--- a/src/components/common/ErrorModal.tsx
+++ b/src/components/common/ErrorModal.tsx
@@ -13,27 +13,27 @@ export const ErrorModal = () => {
   if (error)
     return (
       <Modal title="Error" closeModal={close}>
-        <div className="skt-w flex flex-col flex-1 p-3 items-center justify-between">
-          <div className="skt-w flex flex-col items-center">
-            <AlertCircle className="skt-w text-red-500 w-10 h-10" />
-            <p className="skt-w text-sm text-widget-secondary mt-4 text-center">
+        <div className="skt-w skt-w-flex skt-w-flex-col skt-w-flex-1 skt-w-p-3 skt-w-items-center skt-w-justify-between">
+          <div className="skt-w skt-w-flex skt-w-flex-col skt-w-items-center">
+            <AlertCircle className="skt-w skt-w-text-red-500 skt-w-w-10 skt-w-h-10" />
+            <p className="skt-w skt-w-text-sm skt-w-text-widget-secondary skt-w-mt-4 skt-w-text-center">
               {error}
             </p>
           </div>
-          <div className="skt-w w-full">
-            <p className="skt-w text-center mb-3">
+          <div className="skt-w skt-w-w-full">
+            <p className="skt-w skt-w-text-center skt-w-mb-3">
               <a
                 href="https://socketdottech.zendesk.com/hc/en-us"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="skt-w skt-w-anchor text-sm text-widget-secondary underline hover:text-widget-primary"
+                className="skt-w skt-w-anchor skt-w-text-sm skt-w-text-widget-secondary skt-w-underline hover:skt-w-text-widget-primary"
               >
                 Support
               </a>
             </p>
             <Button
               onClick={close}
-              classNames="bg-red-500 hover:bg-red-600 text-white"
+              classNames="skt-w-bg-red-500 hover:skt-w-bg-red-600 skt-w-text-white"
             >
               Dismiss
             </Button>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -6,10 +6,10 @@ interface headerProp {
 }
 export function Header({ title, children }: headerProp) {
   return (
-    <div className="flex items-center justify-between skt-w text-widget-primary">
+    <div className="skt-w-flex skt-w-items-center skt-w-justify-between skt-w skt-w-text-widget-primary">
       <>
         {typeof title === "string" ? (
-          <span className="font-medium skt-w">{title}</span>
+          <span className="skt-w-font-medium skt-w">{title}</span>
         ) : (
           title
         )}

--- a/src/components/common/InnerCard.tsx
+++ b/src/components/common/InnerCard.tsx
@@ -12,9 +12,11 @@ export const InnerCard = ({
   const { borderRadius } = customSettings.customization;
   return (
     <div
-      className={`skt-w bg-widget-secondary p-3 mt-3 ${classNames || ""}`}
+      className={`skt-w skt-w-bg-widget-secondary skt-w-p-3 skt-w-mt-3 ${
+        classNames || ""
+      }`}
       style={{
-        borderRadius: `calc(0.75rem * ${borderRadius})`
+        borderRadius: `calc(0.75rem * ${borderRadius})`,
       }}
     >
       {children}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -17,27 +17,30 @@ export const Modal = ({
   children,
   disableClose = false,
   classNames,
-  style
+  style,
 }: ModalProps) => {
   const customSettings = useContext(CustomizeContext);
   const { borderRadius } = customSettings.customization;
   return (
-    <animated.div style={style} className="skt-w p-1 w-full h-full absolute top-0 left-0 z-50 bg-black bg-opacity-10">
+    <animated.div
+      style={style}
+      className="skt-w skt-w-p-1 skt-w-w-full skt-w-h-full skt-w-absolute skt-w-top-0 skt-w-left-0 skt-w-z-50 skt-w-bg-black skt-w-bg-opacity-10"
+    >
       <div
-        className={`skt-w w-full h-full bg-widget-primary flex flex-col overflow-hidden ${
+        className={`skt-w skt-w-w-full skt-w-h-full skt-w-bg-widget-primary skt-w-flex skt-w-flex-col skt-w-overflow-hidden ${
           classNames ?? ""
         }`}
         style={{ borderRadius: `calc(0.75rem * ${borderRadius})` }}
       >
-        <div className="skt-w p-3 pt-2.5 border-b border-widget-secondary">
+        <div className="skt-w skt-w-p-3 skt-w-pt-2.5 skt-w-border-b skt-w-border-widget-secondary">
           <Header title={title}>
             {closeModal && (
               <button
                 onClick={closeModal}
                 disabled={disableClose}
-                className="skt-w skt-w-input skt-w-button disabled:opacity-20 disabled:cursor-not-allowed"
+                className="skt-w skt-w-input skt-w-button disabled:skt-w-opacity-20 disabled:skt-w-cursor-not-allowed"
               >
-                <X className="skt-w w-5.5 h-5.5 text-widget-secondary" />
+                <X className="skt-w skt-w-w-5.5 skt-w-h-5.5 skt-w-text-widget-secondary" />
               </button>
             )}
           </Header>

--- a/src/components/common/Popover.tsx
+++ b/src/components/common/Popover.tsx
@@ -19,12 +19,12 @@ export const Popover = ({
   return (
     <div>
       <div
-        className={`skt-w absolute left-0 z-50 ${
-          showPopover ? "visible" : "invisible"
+        className={`skt-w skt-w-absolute skt-w-left-0 skt-w-z-50 ${
+          showPopover ? "skt-w-visible" : "skt-w-invisible"
         } ${classNames ?? ""}`}
       >
         <div
-          className="skt-w text-left bg-black/90 border border-widget-outline text-white text-xs font-normal p-2"
+          className="skt-w skt-w-text-left skt-w-bg-black/90 skt-w-border skt-w-border-widget-outline skt-w-text-white skt-w-text-xs skt-w-font-normal skt-w-p-2"
           style={{ borderRadius: `calc(0.4rem * ${borderRadius})` }}
         >
           {content}
@@ -34,7 +34,7 @@ export const Popover = ({
       <div
         onMouseOver={() => setShowPopover(true)}
         onMouseOut={() => setShowPopover(false)}
-        className={`skt-w ${cursor} flex`}
+        className={`skt-w skt-w-${cursor} skt-w-flex`}
       >
         {children}
       </div>

--- a/src/components/common/RadioCheckbox.tsx
+++ b/src/components/common/RadioCheckbox.tsx
@@ -14,13 +14,13 @@ export const RadioCheckbox = (props: RadioProps) => {
   const { borderRadius } = customSettings.customization;
 
   return (
-    <div className="skt-w relative mx-1">
+    <div className="skt-w skt-w-relative skt-w-mx-1">
       <label
         htmlFor={id}
-        className={`skt-w flex items-center justify-center w-12 relative z-10 p-2 cursor-pointer border border-opacity-40 text-sm font-semibold ${
+        className={`skt-w skt-w-flex skt-w-items-center skt-w-justify-center skt-w-w-12 skt-w-relative skt-w-z-10 skt-w-p-2 skt-w-cursor-pointer skt-w-border skt-w-border-opacity-40 skt-w-text-sm skt-w-font-semibold ${
           checked
-            ? "bg-widget-accent text-widget-onAccent border-widget-accent"
-            : "text-widget-secondary border-widget-secondary-text"
+            ? "skt-w-bg-widget-accent skt-w-text-widget-onAccent skt-w-border-widget-accent"
+            : "skt-w-text-widget-secondary skt-w-border-widget-secondary-text"
         }`}
         style={{ borderRadius: `calc(0.375rem * ${borderRadius})` }}
       >
@@ -30,7 +30,7 @@ export const RadioCheckbox = (props: RadioProps) => {
         type="radio"
         id={id}
         name={name}
-        className="skt-w w-0 h-0 opacity-0 z-0 absolute"
+        className="skt-w skt-w-w-0 skt-w-h-0 skt-w-opacity-0 skt-w-z-0 skt-w-absolute"
         onChange={onChange}
         checked={checked}
       />

--- a/src/components/common/SocketScanLink.tsx
+++ b/src/components/common/SocketScanLink.tsx
@@ -5,12 +5,12 @@ export const SocketScanLink = ({ txHash }: { txHash: string }) => {
 
   return (
     <a
-      className="skt-w skt-w-button text-sm text-widget-secondary hover:text-widget-primary text-center mb-2 flex items-center no-underline justify-center"
+      className="skt-w skt-w-button skt-w-text-sm skt-w-text-widget-secondary hover:skt-w-text-widget-primary skt-w-text-center skt-w-mb-2 skt-w-flex skt-w-items-center skt-w-no-underline skt-w-justify-center"
       href={`https://socketscan.io/tx/${txHash}`}
       target="_blank"
     >
       Track this transaction on SocketScan{" "}
-      <ExternalLink className="w-[18px] h-[18px] ml-1" />
+      <ExternalLink className="skt-w-w-[18px] skt-w-h-[18px] skt-w-ml-1" />
     </a>
   );
 };

--- a/src/components/common/Spinner.tsx
+++ b/src/components/common/Spinner.tsx
@@ -1,9 +1,9 @@
 export const Spinner = ({ size = 6 }: { size?: number }) => {
   return (
     <div
-      className={`skt-w w-${size} h-${size} rounded-full ${
-        size > 8 ? "border-[3px]" : "border-2"
-      } border-widget-secondary-text/30 border-t-widget-accent/100 animate-spin`}
+      className={`skt-w skt-w-w-${size} skt-w-h-${size} skt-w-rounded-full ${
+        size > 8 ? "skt-w-border-[3px]" : "skt-w-border-2"
+      } skt-w-border-widget-secondary-text/30 skt-w-border-t-widget-accent/100 skt-w-animate-spin`}
     ></div>
   );
 };

--- a/src/components/common/Stepper.tsx
+++ b/src/components/common/Stepper.tsx
@@ -7,7 +7,7 @@ interface StepperProps {
 export const Stepper = (props: StepperProps) => {
   const { currentTx, userTxs } = props;
   return (
-    <div className="skt-w flex">
+    <div className="skt-w skt-w-flex">
       {userTxs?.map((x, index) => {
         return (
           <Step
@@ -30,25 +30,31 @@ const Step = (props: {
   const { active, completed, lastItem } = props;
   return (
     <div
-      className={`skt-w flex flex-row items-center ${!lastItem ? "flex-grow" : ""}`}
+      className={`skt-w skt-w-flex skt-w-flex-row skt-w-items-center ${
+        !lastItem ? "skt-w-flex-grow" : ""
+      }`}
     >
       {/* circle */}
       <span
-        className={`skt-w relative w-4 h-4 rounded-full flex justify-center items-center ${
-          completed ? "bg-widget-accent border-0" : ""
+        className={`skt-w skt-w-relative skt-w-w-4 skt-w-h-4 skt-w-rounded-full skt-w-flex skt-w-justify-center skt-w-items-center ${
+          completed ? "skt-w-bg-widget-accent skt-w-border-0" : ""
         } ${
           active
-            ? "border-2 border-widget-accent"
-            : "border border-widget-secondary-text border-opacity-40"
+            ? "skt-w-border-2 skt-w-border-widget-accent"
+            : "skt-w-border skt-w-border-widget-secondary-text skt-w-border-opacity-40"
         } `}
       >
-        {completed && <Check className="skt-w text-widget-onAccent w-3 h-3" />}
+        {completed && (
+          <Check className="skt-w skt-w-text-widget-onAccent skt-w-w-3 skt-w-h-3" />
+        )}
       </span>
       {/* line */}
       {!lastItem && (
         <span
-          className={`skt-w h-px flex-grow ${
-            completed ? "bg-widget-accent" : "bg-widget-secondary-text bg-opacity-40"
+          className={`skt-w skt-w-h-px skt-w-flex-grow ${
+            completed
+              ? "skt-w-bg-widget-accent"
+              : "skt-w-bg-widget-secondary-text skt-w-bg-opacity-40"
           }`}
         ></span>
       )}

--- a/src/components/common/TokenChipPlaceholder.tsx
+++ b/src/components/common/TokenChipPlaceholder.tsx
@@ -6,7 +6,7 @@ export const TokenChipPlaceholder = ({ children }: { children: ReactNode }) => {
   const { borderRadius } = customSettings.customization;
   return (
     <span
-      className={`skt-w h-8 flex items-center justify-center bg-widget-interactive flex-shrink-0 flex-nowrap w-auto overflow-hidden py-1 px-3 text-sm text-widget-on-interactive`}
+      className={`skt-w skt-w-h-8 skt-w-flex skt-w-items-center skt-w-justify-center skt-w-bg-widget-interactive skt-w-flex-shrink-0 skt-w-flex-nowrap skt-w-w-auto skt-w-overflow-hidden skt-w-py-1 skt-w-px-3 skt-w-text-sm skt-w-text-widget-on-interactive`}
       style={{ borderRadius: `calc(1rem * ${borderRadius})` }}
     >
       {children}

--- a/src/components/common/TokenDetail.tsx
+++ b/src/components/common/TokenDetail.tsx
@@ -29,46 +29,48 @@ export const TokenDetail = (props: TokenAssetProps) => {
 
   return (
     <div
-      className={`skt-w flex flex-col flex-1 max-w-full ${
-        rtl ? "items-end" : "flex-row"
+      className={`skt-w skt-w-flex skt-w-flex-col skt-w-flex-1 skt-w-max-w-full ${
+        rtl ? "skt-w-items-end" : "skt-w-flex-row"
       }`}
       style={{ borderRadius: `calc(0.7rem * ${borderRadius})` }}
     >
       <div
-        className={`skt-w flex items-center flex-1 overflow-hidden ${
-          rtl ? "flex-row-reverse" : "flex-row"
+        className={`skt-w skt-w-flex skt-w-items-center skt-w-flex-1 skt-w-overflow-hidden ${
+          rtl ? "skt-w-flex-row-reverse" : "skt-w-flex-row"
         }`}
       >
-        <div className={`skt-w relative flex flex-shrink-0`}>
+        <div className={`skt-w skt-w-relative skt-w-flex skt-w-flex-shrink-0`}>
           <img
             src={token?.logoURI}
-            className="skt-w w-6 h-6 rounded-full border-widget-primary"
+            className="skt-w skt-w-w-6 skt-w-h-6 skt-w-rounded-full skt-w-border-widget-primary"
           />
           {!!refuel?.amount && (
             <img
               src={refuel?.asset?.logoURI}
-              className="skt-w w-6 h-6 rounded-full -ml-2 border-2 border-widget-accent object-cover bg-widget-accent"
+              className="skt-w skt-w-w-6 skt-w-h-6 skt-w-rounded-full skt-w--ml-2 skt-w-border-2 skt-w-border-widget-accent skt-w-object-cover skt-w-bg-widget-accent"
             />
           )}
         </div>
 
         <div
-          className={`skt-w flex flex-col flex-auto overflow-hidden ${
-            rtl ? "items-end mr-2" : "items-start ml-2"
+          className={`skt-w skt-w-flex skt-w-flex-col skt-w-flex-auto skt-w-overflow-hidden ${
+            rtl ? "skt-w-items-end skt-w-mr-2" : "skt-w-items-start skt-w-ml-2"
           }`}
         >
           <span
-            className={`skt-w text-widget-primary w-full font-medium overflow-hidden whitespace-nowrap text-ellipsis flex flex-col ${
-              rtl ? "text-right items-end" : "text-left items-start"
-            } ${small ? "text-xs" : "text-sm"}`}
+            className={`skt-w skt-w-text-widget-primary skt-w-w-full skt-w-font-medium skt-w-overflow-hidden skt-w-whitespace-nowrap skt-w-text-ellipsis skt-w-flex skt-w-flex-col ${
+              rtl
+                ? "skt-w-text-right skt-w-items-end"
+                : "skt-w-text-left skt-w-items-start"
+            } ${small ? "skt-w-text-xs" : "skt-w-text-sm"}`}
           >
             <span>
               {formattedAmount} {token?.symbol}
             </span>
             {refuelEnabled && (
               <span
-                className={`skt-w text-[10px] font-normal text-widget-accent ${
-                  rtl ? "text-right" : "text-left"
+                className={`skt-w skt-w-text-[10px] skt-w-font-normal skt-w-text-widget-accent ${
+                  rtl ? "skt-w-text-right" : "skt-w-text-left"
                 }`}
               >
                 (+ {formattedRefuelAmount} {refuel?.asset?.symbol})
@@ -78,8 +80,8 @@ export const TokenDetail = (props: TokenAssetProps) => {
         </div>
       </div>
       <p
-        className={`skt-w text-xs text-widget-secondary mt-1 ${
-          rtl ? "text-right" : "text-left"
+        className={`skt-w skt-w-text-xs skt-w-text-widget-secondary skt-w-mt-1 ${
+          rtl ? "skt-w-text-right" : "skt-w-text-left"
         }`}
       >
         on {chain?.name}

--- a/src/components/common/TokenDetailsRow.tsx
+++ b/src/components/common/TokenDetailsRow.tsx
@@ -34,20 +34,20 @@ export const TokenDetailsRow = (props: Props) => {
     <button
       onClick={onClick ?? null}
       disabled={!onClick}
-      className={`skt-w skt-w-button skt-w-input px-3 py-4 border-widget-secondary flex flex-col items-start w-full ${
-        !!onClick ? "hover:bg-widget-secondary" : ""
+      className={`skt-w skt-w-button skt-w-input skt-w-px-3 skt-w-py-4 skt-w-border-widget-secondary skt-w-flex skt-w-flex-col skt-w-items-start skt-w-w-full ${
+        !!onClick ? "hover:skt-w-bg-widget-secondary" : ""
       }`}
       style={{ borderRadius: `calc(0.5rem * ${borderRadius})` }}
     >
-      <div className="skt-w flex justify-between items-center w-full">
+      <div className="skt-w skt-w-flex skt-w-justify-between skt-w-items-center skt-w-w-full">
         <TokenDetail
           token={srcDetails?.token}
           amount={srcDetails?.amount}
           refuel={srcRefuel}
         />
         <ArrowDown
-          className={`skt-w w-4 h-4 text-widget-secondary ${
-            false ? "" : "-rotate-90"
+          className={`skt-w skt-w-w-4 skt-w-h-4 skt-w-text-widget-secondary ${
+            false ? "" : "skt-w--rotate-90"
           }`}
         />
         <TokenDetail

--- a/src/index.css
+++ b/src/index.css
@@ -31,7 +31,7 @@ input[type="number"] {
   /* Resetting browser default styles. I have disabled the preflight as it was affecting the integrators' layouts */
 
   .skt-w {
-    @apply box-border p-0 m-0 border-0 border-solid border-[#e5e7eb];
+    @apply skt-w-box-border skt-w-p-0 skt-w-m-0 skt-w-border-0 skt-w-border-solid skt-w-border-[#e5e7eb];
     line-height: 1.15;
     --tw-border-spacing-x: 0;
     --tw-border-spacing-y: 0;
@@ -83,7 +83,7 @@ input[type="number"] {
     cursor: default;
   }
 
-  .skt-w-container {
+  .skt-w-root-container {
     font-family: var(--socket-widget-font-family);
   }
 
@@ -99,7 +99,7 @@ input[type="number"] {
 
   /* for all input elements */
   .skt-w-input {
-    @apply m-0 p-0 border-0 outline-0;
+    @apply skt-w-m-0 skt-w-p-0 skt-w-border-0 skt-w-outline-0;
 
     color: inherit;
     font-family: inherit;
@@ -110,13 +110,13 @@ input[type="number"] {
 
   /* For buttons */
   .skt-w-button {
-    @apply cursor-pointer bg-transparent bg-none;
+    @apply skt-w-cursor-pointer skt-w-bg-transparent skt-w-bg-none;
     text-transform: none;
   }
 
   /* For anchor tags */
   .skt-w-anchor {
-    @apply text-inherit;
+    @apply skt-w-text-inherit;
     text-decoration: none;
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,7 +41,7 @@ export const Bridge = (props: WidgetProps) => {
 
 const IntegrationError = ({ children }) => {
   return (
-    <div className="skt-w rounded-2xl bg-gray-100 w-[360px] p-3 h-[360px] text-center text-gray-500">
+    <div className="skt-w skt-w-rounded-2xl skt-w-bg-gray-100 skt-w-w-[360px] skt-w-p-3 skt-w-h-[360px] skt-w-text-center skt-w-text-gray-500">
       {children}
     </div>
   );

--- a/src/stories/Test.stories.tsx
+++ b/src/stories/Test.stories.tsx
@@ -75,7 +75,10 @@ const Template = (args: WidgetProps) => {
   const _defaultDestNetwork = _destNetworks[0];
 
   return (
-    <div className="skt-w bg-gray-400 p-10" style={{ height: "calc(100vh - 40px)" }}>
+    <div
+      className="skt-w skt-w-bg-gray-400 skt-w-p-10"
+      style={{ height: "calc(100vh - 40px)" }}
+    >
       <p style={{ color: "black" }}>
         User Address : {userAddress}
         <br />
@@ -95,8 +98,10 @@ const Template = (args: WidgetProps) => {
           </button>
         )}
       </div>
-      <Bridge {...args} provider={provider} 
-        // defaultDestNetwork={_defaultDestNetwork} 
+      <Bridge
+        {...args}
+        provider={provider}
+        // defaultDestNetwork={_defaultDestNetwork}
         // destNetworks={_destNetworks}
       />
     </div>
@@ -117,11 +122,11 @@ const Customize = {
 };
 
 function showAlert(value) {
-  console.log('showing alert', value);
+  console.log("showing alert", value);
 }
 
 const UNISWAP_DEFAULT_LIST = "https://gateway.ipfs.io/ipns/tokens.uniswap.org";
-const displayName = <span style={{color: 'red'}}>Salil</span>
+const displayName = <span style={{ color: "red" }}>Salil</span>;
 
 export const Default = Template.bind({});
 Default.args = {
@@ -140,7 +145,7 @@ Default.args = {
   // onDestinationNetworkChange: (value) => console.log('Dest Network:', value),
   // onError: (value) => console.log('Error', value),
   // onSubmit: (value: transactionDetails) => console.log('Submitted: ', value, value?.txData?.[0]?.chainId),
-  
+
   // tokenList: MY_LIST,
   // tokenList: UNISWAP_DEFAULT_LIST,
   // destNetworks: [10],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,7 @@ function withOpacity(variableName) {
 }
 
 module.exports = {
+  prefix: "skt-w-",
   enabled: process.env.NODE_ENV === "publish",
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
@@ -18,10 +19,10 @@ module.exports = {
           accent: withOpacity("--socket-widget-accent-color"),
           onAccent: withOpacity("--socket-widget-on-accent-color"),
           primary: withOpacity("--socket-widget-primary-text-color"),
-          'primary-main': withOpacity("--socket-widget-primary-color"),
+          "primary-main": withOpacity("--socket-widget-primary-color"),
           secondary: withOpacity("--socket-widget-secondary-text-color"),
           outline: withOpacity("--socket-widget-outline-color"),
-          'on-interactive': withOpacity("--socket-widget-on-interactive")
+          "on-interactive": withOpacity("--socket-widget-on-interactive"),
         },
       },
       backgroundColor: {
@@ -31,8 +32,8 @@ module.exports = {
           primary: withOpacity("--socket-widget-primary-color"),
           secondary: withOpacity("--socket-widget-secondary-color"),
           outline: withOpacity("--socket-widget-outline-color"),
-          interactive: withOpacity('--socket-widget-interactive'),
-          'secondary-text': withOpacity('--socket-widget-secondary-text-color')
+          interactive: withOpacity("--socket-widget-interactive"),
+          "secondary-text": withOpacity("--socket-widget-secondary-text-color"),
         },
       },
       borderColor: {
@@ -46,12 +47,12 @@ module.exports = {
       },
       width: {
         5.5: "1.375rem",
-        6.5: "1.625rem"
+        6.5: "1.625rem",
       },
     },
   },
   plugins: [],
   corePlugins: {
     preflight: false,
-  }
+  },
 };


### PR DESCRIPTION
This pull request will contain two features:

1. Config rollup postcss to inject build styles at the very top of the Consumer project so plugin styles can easily overwrite if necessary.

2. Prefix all tailwind classes so in the situation that the Consumer project is using tailwind as well, there will be no conflicts between the plugin and the Consumer.


Breaking changes:

- class `skt-w-container` has been renamed to `skt-w-root-container` since the old name had conflicted with a tailwind class with the same exact name.