### PR TITLE
fix: switch network

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -68,7 +68,7 @@ export const handleNetworkChange = async (provider, chain) => {
     ethers.BigNumber.from(chain?.chainId).toHexString()
   );
   try {
-    await window.ethereum.request({
+    await provider.provider.request({
       method: "wallet_switchEthereumChain",
       params: [{ chainId: formattedChainId }],
     });


### PR DESCRIPTION
### Problem
switching network from wallet connect prompts network change from injected wallet (for example metamask)

### Solution
use provider's `request` method for `wallet_switchEthereumChain`